### PR TITLE
Upgrade + entrypoint interactive or not :

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,15 @@ RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-buster main" > /etc
   apt-get update && \
   apt-get install -y python-dev python-pip python-setuptools python-openssl python-crcmod python-virtualenv \
     python3-dev python3-pip python3-setuptools python3-openssl python3-crcmod python3-virtualenv \
-    virtualenvwrapper sshpass google-cloud-sdk kubectl
+    virtualenvwrapper sshpass google-cloud-sdk kubectl \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV WORKON_HOME=/usr/libexec/virtualenv
 
 ADD ansible.sh /tmp/ansible.sh
 RUN chmod +x /tmp/ansible.sh && /tmp/ansible.sh && rm /tmp/ansible.sh
 
-ENTRYPOINT ["bash","-l"]
+ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-FROM debian:buster
-
-RUN apt-get update && \
-  apt-get install -y curl gnupg2 && \
-  curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-
-RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-buster main" > /etc/apt/sources.list.d/gcloud.list && \
-  apt-get update && \
-  apt-get install -y python-dev python-pip python-setuptools python-openssl python-crcmod python-virtualenv \
-    python3-dev python3-pip python3-setuptools python3-openssl python3-crcmod python3-virtualenv \
-    virtualenvwrapper sshpass google-cloud-sdk kubectl \
-  && rm -rf /var/lib/apt/lists/*
+FROM debian:buster-slim
 
 ENV WORKON_HOME=/usr/libexec/virtualenv
 
 ADD ansible.sh /tmp/ansible.sh
-RUN chmod +x /tmp/ansible.sh && /tmp/ansible.sh && rm /tmp/ansible.sh
-
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+
+RUN apt-get update \
+  && apt-get install -y curl gnupg2 \
+  && echo "deb http://packages.cloud.google.com/apt cloud-sdk-buster main" > /etc/apt/sources.list.d/gcloud.list \
+  && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+  && apt-get update \
+  && apt-get install -y python-dev python-pip python-setuptools python-openssl python-crcmod python-virtualenv \
+      python3-dev python3-pip python3-setuptools python3-openssl python3-crcmod python3-virtualenv \
+      virtualenvwrapper sshpass google-cloud-sdk kubectl \
+  && rm -rf /var/lib/apt/lists/* \
+  && chmod +x /tmp/ansible.sh && /tmp/ansible.sh && rm /tmp/ansible.sh \
+  && chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/ansible.sh
+++ b/ansible.sh
@@ -6,7 +6,7 @@
 
 export ANSIBLE_MIN_VERSION=2.3
 #export ANSIBLE_VERSIONS="2.8 2.6 2.3"
-export ANSIBLE_VERSIONS="2.8 2.7 2.6 2.5 2.4 2.3"
+export ANSIBLE_VERSIONS="2.9 2.8 2.7 2.6 2.5 2.4 2.3"
 
 # If you do not define ANSIBLE_VERSIONS; all ansible minor versions will be installed
 # starting from ANSIBLE_MIN_VERSION (this last variable has no other use besides that)
@@ -101,9 +101,8 @@ for ver in $ANSIBLE_VERSIONS; do
     mkvirtualenv ${ver} -p /usr/bin/python2 --no-site-packages > /dev/null 2>&1
   fi
   workon ${ver}
-  pip install -q packaging appdirs six paramiko PyYAML Jinja2 httplib2 docker-py netaddr ipaddr ansible~=${ver}.0 ansible-lint yamllint ansible-inventory-grapher boto boto3 apache-libcloud python-vagrant
-  pip install -q molecule
-
+  pip install -q packaging appdirs six paramiko PyYAML Jinja2 httplib2 docker-py netaddr ipaddr ansible~=${ver}.0 ansible-lint yamllint ansible-inventory-grapher boto boto3 apache-libcloud python-vagrant molecule
+  
   cpvirtualenv ${ver} $(echo ${ver} | cut -f1-2 -d'.') > /dev/null 2>&1
 
   if [ ${ANSIBLE_CURRENT_VERSION} == ${ver} ]; then
@@ -114,6 +113,7 @@ for ver in $ANSIBLE_VERSIONS; do
     echo "> Setting 'latest' venv to ${ver}"
     cpvirtualenv ${ver} latest > /dev/null 2>&1
   fi
+  deactivate
   chmod -R 777 /usr/libexec/virtualenv/
 done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# [[ -t 0 ]] && echo 'Interactive' || echo 'Not interactive'
+[[ -t 0 ]] && /bin/bash -l || /bin/bash -c "$@"


### PR DESCRIPTION
- Adding 2.9 ansible version ;
- Adding deactivate (for error venv creation)
- Adding apt clean up (best practices)
- Adding entrypoint.sh for interactive mode detection (-it => bash -l, w/o bash -c)